### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # Penrice Academy Calendar Scraper
 
-This project provides a small Python script that collects the term dates from the Penrice Academy website and produces a ready‑to‑import iCalendar file.  The resulting `penrice.ics` file can be opened in any calendar application such as Google Calendar, Outlook or Apple Calendar.
+This repository contains a small Python script that scrapes the term dates published on the [Penrice Academy website](https://www.penriceacademy.org/term-dates) and converts them into a ready‑to‑import iCalendar (``.ics``) file.
+
+Running the scraper generates ``penrice.ics`` which can be added to Google Calendar, Outlook, Apple Calendar or any other iCalendar compatible application.
 
 ## Features
 
-* Downloads the latest term dates from <https://www.penriceacademy.org/term-dates>.
-* Parses single dates and date ranges using BeautifulSoup and regular expressions.
-* Generates standards‑compliant calendar events for each entry.
-* Saves the events to `penrice.ics`.
+* Fetches the latest term dates directly from the academy site using ``requests``.
+* Parses individual dates and date ranges with BeautifulSoup and regular expressions.
+* Automatically prefixes every event title with ``Penrice`` so it is clear where the information came from.
+* Supports multiple events per line (e.g. ``1st Jan & 2nd Jan``).
+* Writes a standards compliant ``.ics`` file and logs any parsing errors to ``log.txt``.
 
 ## Requirements
 
-* Python 3
-* `requests`
-* `beautifulsoup4`
+* Python 3.10 or newer
+* ``requests``
+* ``beautifulsoup4``
 
 Install the dependencies with:
 
@@ -23,13 +26,15 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the script from the repository root:
+From the repository root run:
 
 ```bash
 python generate_ics.py
 ```
 
-The script prints a confirmation message and writes the calendar file.  A portion of the generated output resembles the following:
+The script will download the term dates, create ``penrice.ics`` in the current directory and print a simple confirmation message.  Any parse errors are recorded in ``log.txt`` for inspection.
+
+A typical entry in the generated calendar looks like:
 
 ```text
 BEGIN:VEVENT
@@ -41,6 +46,11 @@ END:VEVENT
 
 ## Customisation
 
-All scraping logic lives in `generate_ics.py`.  To adapt this tool for another website, modify the `URL` constant and adjust the `extract_lines` and `parse_event_line` helpers to suit the new page structure.  Each parsed entry is converted into an iCalendar event by `make_ics_event`.
+If the academy website changes or you would like to adapt the scraper for a different school, edit ``generate_ics.py``:
 
-An example `penrice.ics` is included for reference.
+1. Update the ``URL`` constant to point at the new term dates page.
+2. Adjust ``extract_lines`` and ``parse_event_line`` to match the structure of the new content.
+3. Optionally tweak ``make_ics_event`` to alter how events are formatted.
+
+An example ``penrice.ics`` generated from the current site is included for reference.
+


### PR DESCRIPTION
## Summary
- clarify that the script scrapes the Penrice Academy term dates
- explain requirements and usage more thoroughly
- document logging to `log.txt` and provide an example calendar entry

## Testing
- `pip install -r requirements.txt`
- `python generate_ics.py`

------
https://chatgpt.com/codex/tasks/task_e_68528f66ecd8832da640785a2210bd3d